### PR TITLE
Fix useless array access in MQTT path composition

### DIFF
--- a/fingerprint-mqtt/src/setup.cpp
+++ b/fingerprint-mqtt/src/setup.cpp
@@ -222,7 +222,6 @@ void mqttConnect()
         topic = "/fingerprint/";
         topic.concat(deviceGateId);
         topic.concat("/delete");
-        deleteTopic[topic.length() + 1];
         topic.toCharArray(deleteTopic, topic.length() + 1);
         Serial.print("Delete topic: ");
         Serial.println(deleteTopic);
@@ -230,7 +229,6 @@ void mqttConnect()
         topic = "/fingerprint/";
         topic.concat(deviceGateId);
         topic.concat("/learn");
-        learnTopic[topic.length() + 1];
         topic.toCharArray(learnTopic, topic.length() + 1);
         Serial.print("Learn topic: ");
         Serial.println(learnTopic);


### PR DESCRIPTION
## Description

Fixed a bug in the MQTT path composition in `setup.cpp`. 

**Problem:** In the `mqttConnect()` function, there were two useless lines that accessed array elements without assigning any value:

```cpp
deleteTopic[topic.length() + 1];  // Line 225
learnTopic[topic.length() + 1];  // Line 233
```

These lines had no effect since the arrays were already properly sized (32 bytes) and `toCharArray()` handles the string conversion correctly.

**Fix:** Removed these two useless lines.

## Changes

- `fingerprint-mqtt/src/setup.cpp`: Removed 2 lines of dead code

## Testing

The code was compiling correctly before and after the fix since those lines had no effect on the actual functionality.

@vinz486 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/b14921d3-576e-4d92-9a78-413b0447aa6b)